### PR TITLE
restore utils convertrelated helper

### DIFF
--- a/src/model/BankInfo.js
+++ b/src/model/BankInfo.js
@@ -12,7 +12,9 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
 import AccountTypeEnum from './AccountTypeEnum';
+import Employee from './Employee';
 import RemoteData from './RemoteData';
 
 /**
@@ -57,7 +59,7 @@ class BankInfo {
                 obj['remote_id'] = ApiClient.convertToType(data['remote_id'], 'String');
             }
             if (data.hasOwnProperty('employee')) {
-                obj['employee'] = ApiClient.convertToType(data['employee'], 'String');
+                obj['employee'] = convertRelatedObjectToType(data['employee'], Employee);
             }
             if (data.hasOwnProperty('account_number')) {
                 obj['account_number'] = ApiClient.convertToType(data['account_number'], 'String');

--- a/src/model/Benefit.js
+++ b/src/model/Benefit.js
@@ -12,6 +12,8 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
+import Employee from './Employee';
 import RemoteData from './RemoteData';
 
 /**
@@ -56,7 +58,7 @@ class Benefit {
                 obj['remote_id'] = ApiClient.convertToType(data['remote_id'], 'String');
             }
             if (data.hasOwnProperty('employee')) {
-                obj['employee'] = ApiClient.convertToType(data['employee'], 'String');
+                obj['employee'] = convertRelatedObjectToType(data['employee'], Employee);
             }
             if (data.hasOwnProperty('provider_name')) {
                 obj['provider_name'] = ApiClient.convertToType(data['provider_name'], 'String');

--- a/src/model/Employee.js
+++ b/src/model/Employee.js
@@ -12,10 +12,16 @@
  */
 
 import ApiClient from '../ApiClient';
+import Company from './Company';
+import convertRelatedObjectToType from '../Utils';
+import Employment from './Employment';
 import EmploymentStatusEnum from './EmploymentStatusEnum';
 import EthnicityEnum from './EthnicityEnum';
 import GenderEnum from './GenderEnum';
+import Location from './Location';
 import MaritalStatusEnum from './MaritalStatusEnum';
+import PayGroup from './PayGroup';
+import Team from './Team';
 import RemoteData from './RemoteData';
 
 /**
@@ -63,7 +69,7 @@ class Employee {
                 obj['employee_number'] = ApiClient.convertToType(data['employee_number'], 'String');
             }
             if (data.hasOwnProperty('company')) {
-                obj['company'] = ApiClient.convertToType(data['company'], 'String');
+                obj['company'] = convertRelatedObjectToType(data['company'], Company);
             }
             if (data.hasOwnProperty('first_name')) {
                 obj['first_name'] = ApiClient.convertToType(data['first_name'], 'String');
@@ -90,22 +96,22 @@ class Employee {
                 obj['mobile_phone_number'] = ApiClient.convertToType(data['mobile_phone_number'], 'String');
             }
             if (data.hasOwnProperty('employments')) {
-                obj['employments'] = ApiClient.convertToType(data['employments'], ['String']);
+                obj['employments'] = convertRelatedObjectToType(data['employments'], Employment);
             }
             if (data.hasOwnProperty('home_location')) {
-                obj['home_location'] = ApiClient.convertToType(data['home_location'], 'String');
+                obj['home_location'] = convertRelatedObjectToType(data['home_location'], Location);
             }
             if (data.hasOwnProperty('work_location')) {
-                obj['work_location'] = ApiClient.convertToType(data['work_location'], 'String');
+                obj['work_location'] = convertRelatedObjectToType(data['work_location'], Location);
             }
             if (data.hasOwnProperty('manager')) {
-                obj['manager'] = ApiClient.convertToType(data['manager'], 'String');
+                obj['manager'] = convertRelatedObjectToType(data['manager'], Employee);
             }
             if (data.hasOwnProperty('team')) {
-                obj['team'] = ApiClient.convertToType(data['team'], 'String');
+                obj['team'] = convertRelatedObjectToType(data['team'], Team);
             }
             if (data.hasOwnProperty('pay_group')) {
-                obj['pay_group'] = ApiClient.convertToType(data['pay_group'], 'String');
+                obj['pay_group'] = convertRelatedObjectToType(data['pay_group'], PayGroup);
             }
             if (data.hasOwnProperty('ssn')) {
                 obj['ssn'] = ApiClient.convertToType(data['ssn'], 'String');

--- a/src/model/EmployeePayrollRun.js
+++ b/src/model/EmployeePayrollRun.js
@@ -12,8 +12,11 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
 import Deduction from './Deduction';
 import Earning from './Earning';
+import Employee from './Employee';
+import PayrollRun from './PayrollRun';
 import RemoteData from './RemoteData';
 import Tax from './Tax';
 
@@ -59,10 +62,10 @@ class EmployeePayrollRun {
                 obj['remote_id'] = ApiClient.convertToType(data['remote_id'], 'String');
             }
             if (data.hasOwnProperty('employee')) {
-                obj['employee'] = ApiClient.convertToType(data['employee'], 'String');
+                obj['employee'] = convertRelatedObjectToType(data['employee'], Employee);
             }
             if (data.hasOwnProperty('payroll_run')) {
-                obj['payroll_run'] = ApiClient.convertToType(data['payroll_run'], 'String');
+                obj['payroll_run'] = convertRelatedObjectToType(data['payroll_run'], PayrollRun);
             }
             if (data.hasOwnProperty('gross_pay')) {
                 obj['gross_pay'] = ApiClient.convertToType(data['gross_pay'], 'Number');

--- a/src/model/Employment.js
+++ b/src/model/Employment.js
@@ -12,6 +12,8 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
+import Employee from './Employee';
 import EmploymentTypeEnum from './EmploymentTypeEnum';
 import FlsaStatusEnum from './FlsaStatusEnum';
 import PayCurrencyEnum from './PayCurrencyEnum';
@@ -61,7 +63,7 @@ class Employment {
                 obj['remote_id'] = ApiClient.convertToType(data['remote_id'], 'String');
             }
             if (data.hasOwnProperty('employee')) {
-                obj['employee'] = ApiClient.convertToType(data['employee'], 'String');
+                obj['employee'] = convertRelatedObjectToType(data['employee'], Employee);
             }
             if (data.hasOwnProperty('job_title')) {
                 obj['job_title'] = ApiClient.convertToType(data['job_title'], 'String');

--- a/src/model/Team.js
+++ b/src/model/Team.js
@@ -12,6 +12,7 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
 import RemoteData from './RemoteData';
 
 /**
@@ -59,7 +60,7 @@ class Team {
                 obj['name'] = ApiClient.convertToType(data['name'], 'String');
             }
             if (data.hasOwnProperty('parent_team')) {
-                obj['parent_team'] = ApiClient.convertToType(data['parent_team'], 'String');
+                obj['parent_team'] = convertRelatedObjectToType(data['parent_team'], Team);
             }
             if (data.hasOwnProperty('remote_data')) {
                 obj['remote_data'] = ApiClient.convertToType(data['remote_data'], [RemoteData]);

--- a/src/model/TimeOff.js
+++ b/src/model/TimeOff.js
@@ -12,6 +12,8 @@
  */
 
 import ApiClient from '../ApiClient';
+import convertRelatedObjectToType from '../Utils';
+import Employee from './Employee';
 import RemoteData from './RemoteData';
 import RequestTypeEnum from './RequestTypeEnum';
 import TimeOffStatusEnum from './TimeOffStatusEnum';
@@ -59,10 +61,10 @@ class TimeOff {
                 obj['remote_id'] = ApiClient.convertToType(data['remote_id'], 'String');
             }
             if (data.hasOwnProperty('employee')) {
-                obj['employee'] = ApiClient.convertToType(data['employee'], 'String');
+                obj['employee'] = convertRelatedObjectToType(data['employee'], Employee);
             }
             if (data.hasOwnProperty('approver')) {
-                obj['approver'] = ApiClient.convertToType(data['approver'], 'String');
+                obj['approver'] = convertRelatedObjectToType(data['approver'], Employee);
             }
             if (data.hasOwnProperty('status')) {
                 obj['status'] = ApiClient.convertToType(data['status'], TimeOffStatusEnum);


### PR DESCRIPTION
## Description of the change

Bug fix from 1.0.11 -> 1.0.12:

* we have a custom modification for this sdk where there is a utility method called `convertRelatedObjectToType` that was dropped from 1.0.12; we bring it back here where it used to be.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests, or the description above explains how testing was performed

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or gif attached. Download "Kap" from the Mac App store for easy gif screen capture.

